### PR TITLE
Allow filtering of dataset by years

### DIFF
--- a/app/controllers/datasets.js
+++ b/app/controllers/datasets.js
@@ -17,7 +17,7 @@ export default Ember.Controller.extend({
 
   download_link: Ember.computed('model', 'model.years_available.@each.selected', function() {
     let yearsSelected = this.get('model.years_available') || [];
-    if (!yearsSelected.errors) {
+    if (Ember.compare(Ember.Error, yearsSelected) !== 0) {
       yearsSelected = yearsSelected.filterBy('selected', true);
     }
 
@@ -76,10 +76,13 @@ export default Ember.Controller.extend({
     }
   }),
   selected_rows: Ember.computed('model.years_available.@each.selected', function() {
+    if (Ember.compare(Ember.Error, this.get('model.years_available')) === 0) {
+      return this.get('model.years_available');
+    }
+    let year_column = 'row.' + this.get('model.dataset.yearcolumn');
     let years_available = this.get('model.years_available').filterBy('selected', true).map(selected => selected.year);
-    let emberModelObject = this.get('model');
     return this.get('model.raw_data.rows').filter(function(row) {
-      return years_available.includes(row.acs_year);
+      return years_available.includes(eval(year_column));
     });
   }),
 
@@ -113,6 +116,6 @@ export default Ember.Controller.extend({
       let { min, max, perPage } = this.getProperties('min', 'max', 'perPage');
       this.set('min', min - perPage);
       this.set('max', max - perPage);
-    }
+    },
   }
 });

--- a/app/controllers/datasets.js
+++ b/app/controllers/datasets.js
@@ -75,6 +75,13 @@ export default Ember.Controller.extend({
       return metadata;
     }
   }),
+  selected_rows: Ember.computed('model.years_available.@each.selected', function() {
+    let years_available = this.get('model.years_available').filterBy('selected', true).map(selected => selected.year);
+    let emberModelObject = this.get('model');
+    return this.get('model.raw_data.rows').filter(function(row) {
+      return years_available.includes(row.acs_year);
+    });
+  }),
 
   transformGeospatialMetadata(geospatialMetadata) {
     let columnMetadata = geospatialMetadata['definition']['DEFeatureClassInfo']['GPFieldInfoExs']['GPFieldInfoEx']

--- a/app/controllers/datasets.js
+++ b/app/controllers/datasets.js
@@ -76,7 +76,7 @@ export default Ember.Controller.extend({
     }
   }),
   selected_rows: Ember.computed('model.years_available.@each.selected', function() {
-    if (this.get('model.years_available') instanceof Ember.error) {
+    if (this.get('model.years_available') instanceof Ember.Error) {
       return this.get('model.years_available');
     }
     let years_available = this.get('model.years_available').filterBy('selected', true).map(selected => selected.year);

--- a/app/controllers/datasets.js
+++ b/app/controllers/datasets.js
@@ -79,10 +79,9 @@ export default Ember.Controller.extend({
     if (Ember.compare(Ember.Error, this.get('model.years_available')) === 0) {
       return this.get('model.years_available');
     }
-    let year_column = 'row.' + this.get('model.dataset.yearcolumn');
     let years_available = this.get('model.years_available').filterBy('selected', true).map(selected => selected.year);
-    return this.get('model.raw_data.rows').filter(function(row) {
-      return years_available.includes(eval(year_column));
+    return this.get('model.raw_data.rows').filter((row) => {
+      return years_available.includes(row[this.get('model.dataset.yearcolumn')]);
     });
   }),
 

--- a/app/controllers/datasets.js
+++ b/app/controllers/datasets.js
@@ -45,7 +45,9 @@ export default Ember.Controller.extend({
     if (this.get('model.dataset.hasYears')) {
       let yearsSelected = this.get('model.years_available').filterBy('selected', true);
       let latest = yearsSelected[yearsSelected.length-1];
-      where = ` WHERE a.${this.get('model.dataset.yearcolumn')} IN ('${latest.year}')`;
+      if(latest) {
+        where = ` WHERE a.${this.get('model.dataset.yearcolumn')} IN ('${latest.year}')`;
+      }
     }
 
     let select = `SELECT ${fields}, b.the_geom, b.the_geom_webmercator `;

--- a/app/controllers/datasets.js
+++ b/app/controllers/datasets.js
@@ -76,7 +76,7 @@ export default Ember.Controller.extend({
     }
   }),
   selected_rows: Ember.computed('model.years_available.@each.selected', function() {
-    if (Ember.compare(Ember.Error, this.get('model.years_available')) === 0) {
+    if (this.get('model.years_available') instanceof Ember.error) {
       return this.get('model.years_available');
     }
     let years_available = this.get('model.years_available').filterBy('selected', true).map(selected => selected.year);

--- a/app/models/dataset.js
+++ b/app/models/dataset.js
@@ -13,9 +13,5 @@ export default DS.Model.extend({
   source: DS.attr('string'),
   hasYears: Ember.computed('yearcolumn', function() {
     return !!this.get('yearcolumn');
-  }),
-  isMunicipal: Ember.computed('menu3', function() {
-    let table_name = this.get('menu3');
-    return /(Municipal)/.test(table_name);
   })
 });

--- a/app/routes/datasets.js
+++ b/app/routes/datasets.js
@@ -20,8 +20,8 @@ export default class extends Route {
     // SQL queries
     let url = `${config.dataBrowserEndpoint}select * from ${dataset.get('table_name')} `;
 
-    if (dataset.get('isMunicipal') && dataset.get('hasYears')) {
-      url += `where ${yearcolumn}=(select max(${yearcolumn}) from ${dataset.get('table_name')}) order by municipal ASC;`;
+    if (dataset.get('hasYears')) {
+      url += `order by ${yearcolumn} ASC;`;
     } else {
       url += ' LIMIT 50;';
     }

--- a/app/routes/datasets.js
+++ b/app/routes/datasets.js
@@ -48,7 +48,10 @@ export default class extends Route {
     let years_available = this.get('ajax').request(years_url).then(function(years) {
       if (dataset.get('hasYears')) {
         let keys = years.rows.mapBy(yearcolumn).sort();
-        let obj = keys.map((el) => { return EmberObject.create({ year: el, selected: true }); });
+        let obj = keys.map((el, index) => {
+          let isSelected = (index === 0);
+          return EmberObject.create({ year: el, selected: isSelected });
+        });
         return obj;
       } else {
         return A([]);

--- a/app/routes/datasets.js
+++ b/app/routes/datasets.js
@@ -47,7 +47,7 @@ export default class extends Route {
 
     let years_available = this.get('ajax').request(years_url).then(function(years) {
       if (dataset.get('hasYears')) {
-        let keys = years.rows.mapBy(yearcolumn).sort();
+        let keys = years.rows.mapBy(yearcolumn).sort().reverse();
         let obj = keys.map((el, index) => {
           let isSelected = (index === 0);
           return EmberObject.create({ year: el, selected: isSelected });

--- a/app/templates/datasets.hbs
+++ b/app/templates/datasets.hbs
@@ -83,15 +83,8 @@
 
     <div class="scroll-horizontal-rotated ui raised center aligned segment">
       <div class="cancel-rotate">
-        <div class="ui inverted segment">
-          {{#unless model.dataset.isMunicipal}}
-            Note: Viewing First 50 rows; Filters apply only to data export.
-          {{else}}
-            Note: Viewing Latest Year available; Filters apply only to data export.
-          {{/unless}}
-        </div>
         {{#if (not model.raw_data.errors)}}
-          {{ui-table model=(slice min max model.raw_data.rows) fields=model.raw_data.fields metadata=formattedMetadata}}
+          {{ui-table model=(slice min max selected_rows) fields=model.raw_data.fields metadata=formattedMetadata}}
         {{else}}
           {{#each model.raw_data.errors as |error|}}
             <h3 class="ui icon header">

--- a/app/templates/datasets.hbs
+++ b/app/templates/datasets.hbs
@@ -111,7 +111,6 @@
             </h3>
           {{else}}
             {{ui-table model=(slice min max selected_rows) fields=model.raw_data.fields metadata=formattedMetadata}}
-            }
           {{/if}}
         {{/if}}
       </div>

--- a/app/templates/datasets.hbs
+++ b/app/templates/datasets.hbs
@@ -83,9 +83,7 @@
 
     <div class="scroll-horizontal-rotated ui raised center aligned segment">
       <div class="cancel-rotate">
-        {{#if (not model.raw_data.errors)}}
-          {{ui-table model=(slice min max selected_rows) fields=model.raw_data.fields metadata=formattedMetadata}}
-        {{else}}
+        {{#if model.raw_data_errors}}
           {{#each model.raw_data.errors as |error|}}
             <h3 class="ui icon header">
               <i class="warning sign icon"></i>
@@ -100,10 +98,24 @@
               </div>
             </h3>
           {{/each}}
+        {{else}}
+          {{#if model.raw_data.message}}
+            <h3 class="ui icon header">
+              <i class="warning sign icon"></i>
+              <div class="content">
+                Oops.
+                <div class="sub header">
+                  We probably just need to sync and/or update permissions for this dataset.<br/><br/> We've been notified of the error and will work on it. If you'd like to contact us, we can be reached at <a href="mailto:data@mapc.org">data@mapc.org</a>
+                </div>
+              </div>
+            </h3>
+          {{else}}
+            {{ui-table model=(slice min max selected_rows) fields=model.raw_data.fields metadata=formattedMetadata}}
+            }
+          {{/if}}
         {{/if}}
       </div>
     </div>
-
   </div>
 </div>
 {{outlet}}

--- a/config/environment.js
+++ b/config/environment.js
@@ -33,11 +33,11 @@ module.exports = function(environment) {
   };
 
   if (environment === 'development') {
-    ENV.metadataHost = 'http://staging.datacommon.mapc.org';
+    ENV.metadataHost = 'https://staging.datacommon.mapc.org';
   }
 
   if (environment === 'production') {
-    ENV.metadataHost = 'http://datacommon.mapc.org';
+    ENV.metadataHost = 'https://datacommon.mapc.org';
   }
 
   if (environment === 'test') {

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,7 +4,9 @@ const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
 module.exports = function(defaults) {
   let app = new EmberApp(defaults, {
-    // Add options here
+    babel: {
+        sourceMaps: 'inline'
+      }
   });
 
   // Use `app.import` to add additional libraries to the generated

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -3,15 +3,14 @@
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
 module.exports = function(defaults) {
-  var app
-  if(EmberApp.env() !== 'production') {
+  let app = new EmberApp(defaults);
+  if(process.env.EMBER_ENV !== 'production') {
+
     app = new EmberApp(defaults, {
       babel: {
           sourceMaps: 'inline'
         }
     });
-  } else {
-    app = new EmberApp(defaults);
   }
   // Use `app.import` to add additional libraries to the generated
   // output files.

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -3,12 +3,16 @@
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
 module.exports = function(defaults) {
-  let app = new EmberApp(defaults, {
-    babel: {
-        sourceMaps: 'inline'
-      }
-  });
-
+  var app
+  if(EmberApp.env() !== 'production') {
+    app = new EmberApp(defaults, {
+      babel: {
+          sourceMaps: 'inline'
+        }
+    });
+  } else {
+    app = new EmberApp(defaults);
+  }
   // Use `app.import` to add additional libraries to the generated
   // output files.
   //


### PR DESCRIPTION
This commit allows the user to filter the dataset by values available in the years column in the user interface. This also addresses #1 by removing the isMunicipal property of the model since it was merely checking to see if the table had the word “Municipal” in it to then sort by municipality.

Resolves mapc/datacommon#65