### PR TITLE
Disable ESLINT in Test Suite

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -9,7 +9,8 @@ module.exports = function(defaults) {
     app = new EmberApp(defaults, {
       babel: {
           sourceMaps: 'inline'
-        }
+        },
+      hinting: process.env.EMBER_ENV !== 'test'
     });
   }
   // Use `app.import` to add additional libraries to the generated


### PR DESCRIPTION
This commit disables eslint in our test suite to cut down on noise when running the ember test suite.