### PR TITLE
Add Download Metadata Action

### DIFF
--- a/app/controllers/datasets.js
+++ b/app/controllers/datasets.js
@@ -3,7 +3,6 @@ import config from '../config/environment';
 import { service } from '@ember-decorators/service';
 import { computed, action } from '@ember-decorators/object';
 
-
 export default class extends Controller {
 
   @service ajax
@@ -148,6 +147,37 @@ export default class extends Controller {
     return `${config.dataBrowserEndpoint}${sql}&format=${format}&filename=${tabular}`;
   }
 
+  @action
+  downloadMetadata(metadata) {
+    const keys = Object.keys(metadata[0])
+
+    const values = metadata.map(row => {
+      return keys.map(key => { return row[key]; })
+    })
+
+    const rows = values.map(row => {
+      return row.reduce((a,b) => a + ',' + b);
+    })
+
+
+    const csvHeader = "data:text/csv;charset=utf-8,";
+
+    const documentHeader = keys;
+    const documentRows = rows.reduce((a,b) => `${a}\n${b}`)
+
+    const documentStructure = [[documentHeader], documentRows].reduce((a,b) => a.concat(b));
+    const documentBody = documentStructure.reduce((a,b) => `${a}\n${b}`)
+
+    const csvFile = csvHeader + documentBody;
+    const encoded = encodeURI(csvFile);
+
+    const link = document.createElement('a');
+    link.setAttribute('href', encoded);
+    link.setAttribute('download', `metadata.csv`);
+
+    document.body.appendChild(link);
+    link.click();
+  }
 
   @action
   toggle(year) {

--- a/app/controllers/datasets.js
+++ b/app/controllers/datasets.js
@@ -173,7 +173,7 @@ export default class extends Controller {
 
     const link = document.createElement('a');
     link.setAttribute('href', encoded);
-    link.setAttribute('download', `metadata.csv`);
+    link.setAttribute('download', `${metadata[2].details}-metadata.csv`);
 
     document.body.appendChild(link);
     link.click();

--- a/app/templates/datasets.hbs
+++ b/app/templates/datasets.hbs
@@ -46,11 +46,9 @@
           Download:
 
           <div class="download-buttons gradient-{{downloadButtonsLength}}">
-            {{#if model.metadata.rows}}
-              <a class="button lift" href={{download_link_metadata}} download={{concat model.dataset.table_name '_meta'}}>
-                meta
-              </a>
-            {{/if}}
+            <a class="button lift" {{action 'downloadMetadata' model.metadata}}>
+              meta
+            </a>
 
             <a class="button lift" href={{download_link}} download={{model.dataset.table_name}}>
               .csv


### PR DESCRIPTION
This commit adds an action for downloading metadata called downloadMetadata and making it available in the template.

Resolves MAPC/datacommon#63