### PR TITLE
Resolve #107 Show Shapefile Download Icon

### DIFF
--- a/app/controllers/datasets.js
+++ b/app/controllers/datasets.js
@@ -102,9 +102,9 @@ export default class extends Controller {
   }
 
 
-  @computed('model', 'model.years_available.@each.selected')
+  @computed('model')
   get download_link_shapefile() {
-    return this.spatial_query('shp');
+    return window.location.origin + '/shapefile?table=' + this.get('model.metadata.definition.DEFeatureClassInfo.Name')
   }
 
 

--- a/app/templates/datasets.hbs
+++ b/app/templates/datasets.hbs
@@ -58,17 +58,12 @@
               <a class="button lift" href={{download_link_shapefile}} download={{model.dataset.table_name}}>
                 .shp
               </a>
-              <a class="button lift" href={{download_link_geojson}} download={{model.dataset.table_name}}>
-                .geojson
-              </a>
             {{/unless}}
           </div>
         </div>
       </div>
     </div>
   </div>
-
-  {{debugger}}
 
   <div class="table-wrapper">
     <div class="container tight">

--- a/app/templates/datasets.hbs
+++ b/app/templates/datasets.hbs
@@ -54,7 +54,7 @@
               .csv
             </a>
 
-            {{#unless model.raw_data.spatialMetaData}}
+            {{#unless (eq model.dataset.schemaname 'tabular')}}
               <a class="button lift" href={{download_link_shapefile}} download={{model.dataset.table_name}}>
                 .shp
               </a>

--- a/app/templates/datasets.hbs
+++ b/app/templates/datasets.hbs
@@ -54,19 +54,21 @@
               .csv
             </a>
 
-            {{#if model.raw_data.spatialMetaData}}
+            {{#unless model.raw_data.spatialMetaData}}
               <a class="button lift" href={{download_link_shapefile}} download={{model.dataset.table_name}}>
                 .shp
               </a>
               <a class="button lift" href={{download_link_geojson}} download={{model.dataset.table_name}}>
                 .geojson
               </a>
-            {{/if}}
+            {{/unless}}
           </div>
         </div>
       </div>
     </div>
   </div>
+
+  {{debugger}}
 
   <div class="table-wrapper">
     <div class="container tight">


### PR DESCRIPTION
Show shapefile download button for the appropriate kinds of datasets. Now we will stop showing them for tabular datasets and show it for geospatial datasets.