### PR TITLE
Fix Pagination

### DIFF
--- a/app/controllers/datasets.js
+++ b/app/controllers/datasets.js
@@ -24,7 +24,7 @@ export default class extends Controller {
   }
 
 
-  @computed('min', 'max')
+  @computed('min', 'max', 'selected_rows.length')
   get page() {
     return Math.ceil(this.get('max') / this.get('perPage'));
   }
@@ -193,6 +193,15 @@ export default class extends Controller {
   @action
   toggle(year) {
     year.toggleProperty('selected');
+    const {
+      max,
+      perPage
+    } = this.getProperties('max', 'perPage');
+
+    if(max > this.get('selected_rows.length')) {
+      this.set('max', this.get('selected_rows.length'));
+      this.set('min', this.get('selected_rows.length') - perPage)
+    }
   }
 
 

--- a/app/controllers/datasets.js
+++ b/app/controllers/datasets.js
@@ -18,9 +18,9 @@ export default class extends Controller {
   }
 
 
-  @computed('model.raw_data.rows.length')
+  @computed('selected_rows.length')
   get pageCount() {
-    return Math.ceil(this.get('model.raw_data.rows.length') / this.get('perPage'));
+    return Math.ceil(this.get('selected_rows.length') / this.get('perPage'));
   }
 
 
@@ -234,7 +234,7 @@ export default class extends Controller {
   @action
   last() {
     const perPage = this.get('perPage');
-    const { length } = this.get('model.raw_data.rows');
+    const { length } = this.get('selected_rows');
 
     this.set('min', length - (length % perPage));
     this.set('max', length);


### PR DESCRIPTION
Resolve MAPC/datacommon#117 by changing the pageCount and length to reference the data in the selected rows computed property instead of the entire raw dataset. This makes it so that the user now goes to the correct page when clicking the end of pages.