### PR TITLE
Migrate PRQL to HTTPS

### DIFF
--- a/app/routes/datasets.js
+++ b/app/routes/datasets.js
@@ -44,7 +44,7 @@ export default class extends Route {
 
     // check to see if table_data_browser entry marks it as tabular or not
     const tableSchema = dataset.get('schemaname') === 'tabular' ? 'tabular' : 'geospatial';
-    let meta_url = `${config.host}${tableSchema}?tables=${dataset.get('table_name')}`;
+    let meta_url = `${config.host}/${tableSchema}?tables=${dataset.get('table_name')}`;
     let years_url = `${config.dataBrowserEndpoint}select distinct(${yearcolumn}) from ${prqlSchema}.${dataset.get('table_name')} limit 50&token=${token}`;
 
     // models

--- a/config/environment.js
+++ b/config/environment.js
@@ -6,8 +6,8 @@ module.exports = function(environment) {
     environment,
     rootURL: '/',
     locationType: 'auto',
-    dataBrowserIndex: 'http://prql.mapc.org/?query=select%20*%20from%20tabular._data_browser%20where%20schemaname%3D%27tabular%27%20or%20schemaname%3D%27mapc%27%20and%20active%3D%27Y%27&token=16a2637ee33572e46f5609a578b035dc',
-    dataBrowserEndpoint: 'http://prql.mapc.org/?query=',
+    dataBrowserIndex: 'https://prql.mapc.org/?query=select%20*%20from%20tabular._data_browser%20where%20schemaname%3D%27tabular%27%20or%20schemaname%3D%27mapc%27%20and%20active%3D%27Y%27&token=16a2637ee33572e46f5609a578b035dc',
+    dataBrowserEndpoint: 'https://prql.mapc.org/?query=',
     spatialJoinFields: [  { field: 'ct10_id', table: 'census_2010_tracts'},
                           { field: 'muni_id', table: 'ma_municipalities'}
                           // { field: 'bg10_id', table: ''}

--- a/config/environment.js
+++ b/config/environment.js
@@ -38,7 +38,7 @@ module.exports = function(environment) {
   };
 
   if (environment === 'development') {
-    ENV.host = 'https://staging.datacommon.mapc.org/';
+    ENV.host = 'https://staging.datacommon.mapc.org';
   }
 
   if (environment === 'staging') {

--- a/config/environment.js
+++ b/config/environment.js
@@ -6,7 +6,7 @@ module.exports = function(environment) {
     environment,
     rootURL: '/',
     locationType: 'auto',
-    dataBrowserIndex: 'https://prql.mapc.org/?query=select%20*%20from%20tabular._data_browser%20where%20schemaname%3D%27tabular%27%20or%20schemaname%3D%27mapc%27%20and%20active%3D%27Y%27&token=16a2637ee33572e46f5609a578b035dc',
+    dataBrowserIndex: 'https://prql.mapc.org/?token=16a2637ee33572e46f5609a578b035dc&query=SELECT%20*%20FROM%20tabular._data_browser%20WHERE%20active%20%3D%20%27Y%27%20ORDER%20BY%20menu1,menu2,menu3%20ASC',
     dataBrowserEndpoint: 'https://prql.mapc.org/?query=',
     spatialJoinFields: [  { field: 'ct10_id', table: 'census_2010_tracts'},
                           { field: 'muni_id', table: 'ma_municipalities'}


### PR DESCRIPTION
Because of mixed contet issues on staging where we cannot mix HTTP and HTTPS this commit updates the PRQL endpoints to use HTTPS.

Also resolves https://github.com/MAPC/datacommon/issues/135 by sorting category names alphabetically.