### PR TITLE
Fix Parcel Display Bug

### DIFF
--- a/app/controllers/datasets.js
+++ b/app/controllers/datasets.js
@@ -55,7 +55,7 @@ export default class extends Controller {
   @computed('model.years_available.@each.selected')
   get selected_rows() {
     if (this.get('model.years_available') instanceof Ember.Error) {
-      return this.get('model.years_available');
+      return this.get('model.raw_data.rows');
     }
     if(this.get('model.years_available').length === 0) {
       return this.get('model.raw_data.rows');


### PR DESCRIPTION
When attempting to view the “Massachusetts Land Parcel Database (Metro Boston Region)” the rows would not display in the user interface despite the fact that the data was loading. This resolves the issue by properly returning the rows instead of the list of available years for the selected_rows computed property when the years_available is an Ember error.