### PR TITLE
Metadata Guard Clause

### DIFF
--- a/app/controllers/datasets.js
+++ b/app/controllers/datasets.js
@@ -34,7 +34,7 @@ export default class extends Controller {
   get formattedMetadata() {
     const metadata = this.get('model.metadata');
 
-    if (typeof metadata != 'undefined' && 'definition' in metadata) {
+    if (metadata && 'definition' in metadata) {
       const columnMetadata = metadata['definition']['DEFeatureClassInfo']['GPFieldInfoExs']['GPFieldInfoEx'];
       const title = {name: "title", alias: "Title", details: metadata['documentation']['metadata']['dataIdInfo']['idCitation']['resTitle']}
       const tbl_table = {name: "tbl_table", alias: "Table Name", details: metadata['documentation']['metadata']['Esri']['DataProperties']['itemProps']['itemName']}

--- a/app/controllers/datasets.js
+++ b/app/controllers/datasets.js
@@ -34,8 +34,7 @@ export default class extends Controller {
   get formattedMetadata() {
     const metadata = this.get('model.metadata');
 
-
-    if ('definition' in metadata) {
+    if (typeof metadata != 'undefined' && 'definition' in metadata) {
       const columnMetadata = metadata['definition']['DEFeatureClassInfo']['GPFieldInfoExs']['GPFieldInfoEx'];
       const title = {name: "title", alias: "Title", details: metadata['documentation']['metadata']['dataIdInfo']['idCitation']['resTitle']}
       const tbl_table = {name: "tbl_table", alias: "Table Name", details: metadata['documentation']['metadata']['Esri']['DataProperties']['itemProps']['itemName']}


### PR DESCRIPTION
This adds an additional check to allow the dataset to still load even if the metadata endpoint fails to find the metadata for a dataset.