### PR TITLE
Update metadata endpoint

### DIFF
--- a/app/routes/datasets.js
+++ b/app/routes/datasets.js
@@ -43,8 +43,8 @@ export default class extends Route {
     }
 
     // check to see if table_data_browser entry marks it as tabular or not
-    const tableSchema = dataset.get('schemaname') === 'tabular' ? 'tabular' : 'geospatial';
-    let meta_url = `${config.host}/${tableSchema}?tables=${dataset.get('table_name')}`;
+    const tableDatabase = dataset.get('db_name');
+    let meta_url = `${config.host}/${tableDatabase}?tables=${dataset.get('table_name')}`;
     let years_url = `${config.dataBrowserEndpoint}select distinct(${yearcolumn}) from ${prqlSchema}.${dataset.get('table_name')} limit 50&token=${token}`;
 
     // models

--- a/config/environment.js
+++ b/config/environment.js
@@ -38,7 +38,7 @@ module.exports = function(environment) {
   };
 
   if (environment === 'development') {
-    ENV.host = 'https://staging.datacommon.mapc.org';
+    ENV.host = 'http://localhost:9292';
   }
 
   if (environment === 'staging') {


### PR DESCRIPTION
This commit refactors the metadata endpoint call to refer to the database name instead of the schema name when summoning metadata.

This will break databrowser until MAPC/datacommon#155 is merged.

It also changes development to point to localhost for the metadata endpoints in order to allow for easier local testing.