### PR TITLE
Disable CSS minification that is removing typekit import

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -18,6 +18,10 @@ module.exports = function(defaults) {
       babel: {
         sourceMaps: 'inline',
       },
+      minifyCSS: {
+        enabled: false,
+        options: {}
+      },
     } : config
   ));
 


### PR DESCRIPTION
The databrowser header looks like this:
![screen shot 2018-10-03 at 10 13 51 am](https://user-images.githubusercontent.com/6565554/46416321-4adbb500-c6f5-11e8-9fe9-e1619714e88a.png)

This PR temporarily disables Ember's CSS minification that is currently stripping the import for typekit.