### PR TITLE
Make paginator more aware of selected years

### DIFF
--- a/app/controllers/datasets.js
+++ b/app/controllers/datasets.js
@@ -247,7 +247,7 @@ export default class extends Controller {
   previous() {
     const { min, perPage, page } = this.getProperties('min', 'perPage', 'page');
 
-    if (page !== 1) {
+    if (page > 1) {
       this.set('min', min - perPage);
       this.set('max', min);
     }
@@ -256,8 +256,10 @@ export default class extends Controller {
 
   @action
   first() {
-    this.set('min', 0);
-    this.set('max', this.get('perPage'));
+    if (this.get('page') > 1) {
+      this.set('min', 0);
+      this.set('max', this.get('perPage'));
+    }
   }
 
 
@@ -266,8 +268,10 @@ export default class extends Controller {
     const perPage = this.get('perPage');
     const { length } = this.get('selected_rows');
 
-    this.set('min', length - (length % perPage));
-    this.set('max', length);
+    if (this.get('pageCount') !== 0) {
+      this.set('min', length - (length % perPage));
+      this.set('max', length);
+    }
   }
 
 }

--- a/app/templates/datasets.hbs
+++ b/app/templates/datasets.hbs
@@ -134,7 +134,7 @@
           </div>
 
           <div
-            class="button-wrapper lift {{if (gte max model.raw_data.rows.length) "disabled"}}"
+            class="button-wrapper lift {{if (gte max selected_rows.length) "disabled"}}"
           >
             <button onclick={{action "next"}}>&gt;</button>
             <span class="separator"></span>


### PR DESCRIPTION
Resolves https://github.com/MAPC/datacommon/issues/194

This makes the paginator aware of years selected so it doesn't calculate negative boundaries when there is no data present to act as the starting count for the paginator.