### PR TITLE
Change Browser download button label for metadata

### DIFF
--- a/app/templates/datasets.hbs
+++ b/app/templates/datasets.hbs
@@ -52,7 +52,7 @@
 
           <div class="download-buttons gradient-{{downloadButtonsLength}}">
             <a class="button lift" {{action "downloadMetadata" formattedMetadata}}>
-              meta
+              metadata
             </a>
 
             <a


### PR DESCRIPTION
'Twas 'meta', 'tis 'metadata' henceforth. 

Resolves https://github.com/MAPC/datacommon/issues/166.