### PR TITLE
Fix render for parcel datasets

### DIFF
--- a/app/controllers/datasets.js
+++ b/app/controllers/datasets.js
@@ -60,6 +60,7 @@ export default class extends Controller {
     const metadata = (this.get('formattedMetadata') || []).map(x => x.name);
     const fieldNames = Object.keys(this.get('model.raw_data.fields') || {});
     const fields = [];
+    const withoutMeta = [];
 
     fieldNames.forEach(field => {
       var fieldMetaIndex = metadata.indexOf(field);
@@ -67,9 +68,12 @@ export default class extends Controller {
       if (fieldMetaIndex !== -1) {
         fields[fieldMetaIndex] = field;
       }
+      else {
+        withoutMeta.push(field);
+      }
     });
 
-    return fields.filter(x => x);
+    return [...fields.filter(x => x), ...withoutMeta];
   }
 
 
@@ -78,7 +82,7 @@ export default class extends Controller {
     if (this.get('model.years_available') instanceof EmberError) {
       return this.get('model.raw_data.rows');
     }
-    if(this.get('model.years_available').length === 0) {
+    if((this.get('model.years_available') || []).length === 0) {
       return this.get('model.raw_data.rows');
     }
 

--- a/app/controllers/datasets.js
+++ b/app/controllers/datasets.js
@@ -83,7 +83,7 @@ export default class extends Controller {
       return this.get('model.raw_data.rows');
     }
     if((this.get('model.years_available') || []).length === 0) {
-      return this.get('model.raw_data.rows');
+      return this.get('model.raw_data.rows') || [];
     }
 
     let years_available = this.get('model.years_available')

--- a/app/routes/datasets.js
+++ b/app/routes/datasets.js
@@ -53,7 +53,7 @@ export default class extends Route {
       this.get('ajax')
         .request(years_url)
         .then(years => {
-          if (dataset.get('hasYears')) {
+          if (dataset.get('hasYears') && years.rows) {
             const keys = years.rows.mapBy(yearcolumn).sort().reverse();
             const obj = keys.map((el, index) => {
               var isSelected = (index === 0);

--- a/config/environment.js
+++ b/config/environment.js
@@ -38,8 +38,7 @@ module.exports = function(environment) {
   };
 
   if (environment === 'development') {
-    //ENV.host = 'http://localhost:9292';
-    ENV.host = 'https://staging.datacommon.mapc.org';
+    ENV.host = 'http://localhost:9292';
   }
 
   if (environment === 'staging') {

--- a/config/environment.js
+++ b/config/environment.js
@@ -38,7 +38,8 @@ module.exports = function(environment) {
   };
 
   if (environment === 'development') {
-    ENV.host = 'http://localhost:9292';
+    //ENV.host = 'http://localhost:9292';
+    ENV.host = 'https://staging.datacommon.mapc.org';
   }
 
   if (environment === 'staging') {


### PR DESCRIPTION
Resolves https://github.com/MAPC/datacommon/issues/195

Parcel datasets weren't loading if they didn't have the proper amount of metadata associated. The bug was introduced by my column ordering fix which neglected to restore field names after reallocated the field order to a different array.