### PR TITLE
Ensure that datasets Route supplies Array interface for years_available

### DIFF
--- a/app/routes/datasets.js
+++ b/app/routes/datasets.js
@@ -66,7 +66,7 @@ export default class extends Route {
           }
         })
         .catch(handleErrors)
-    ): null;
+    ) : [];
 
     return RSVP.hash({
       dataset,


### PR DESCRIPTION
This prevents breaking when datasets without years are being viewed in the table by providing an Array interface for the Controller to interact with.

Resolves https://github.com/MAPC/datacommon/issues/206