### PR TITLE
Resolve MAPC/datacommon#210 Fix CSV Download

### DIFF
--- a/app/controllers/datasets.js
+++ b/app/controllers/datasets.js
@@ -120,7 +120,7 @@ export default class extends Controller {
     const yearcolumn = this.get('model.dataset.yearcolumn');
     const yearsAvailable = this.get('yearsAvailable').join(',');
 
-    return (yearsAvailable === "" && yearcolumn) ? null : `&years=${yearsAvailable}&year_col=${yearcolumn}`;
+    return (yearsAvailable === "" && yearcolumn === null) ? "" : `&years=${yearsAvailable}&year_col=${yearcolumn}`;
   }
 
 


### PR DESCRIPTION
When the yearcolumn value was null, we were returning the text string “null” into the year parameter in the url. This lead our back-end to serve up a CSV with data from “null” (or none) years. What we really wanted was to serve up the entire buffet of data. To resolve this we updated the check of the yearcolumn value to see if it is equivalent to null, and then return an empty string if that is the case. Otherwise we return the year_col and years params so that we appropriately filter our downloaded datasets.